### PR TITLE
Verify state

### DIFF
--- a/src/main/groovy/org/cassalog/core/CassalogImpl.groovy
+++ b/src/main/groovy/org/cassalog/core/CassalogImpl.groovy
@@ -43,6 +43,8 @@ class CassalogImpl implements Cassalog {
 
   PreparedStatement insertSchemaChange
 
+  PreparedStatement updateAppliedAt
+
   ConsistencyLevel consistencyLevel
 
   @Override
@@ -84,9 +86,9 @@ class CassalogImpl implements Cassalog {
         applyChangeSet(changeSets[0], 0, false)
         createChangeLogTableIfNecessary()
         initPreparedStatements()
-        executeCQL(insertSchemaChange.bind(0, 0, changeSets[0].version, new Date(), changeSets[0].hash,
-            changeSets[0].author, changeSets[0].description, changeSets[0].tags))
-//        applyChangeSet(changeSets[0], 0, true)
+        executeCQL(insertSchemaChange.bind(0, 0, changeSets[0].version, changeSets[0].hash, changeSets[0].author,
+            changeSets[0].description, changeSets[0].tags))
+        executeCQL(updateAppliedAt.bind(new Date(), 0, 0))
       }
     }
 
@@ -121,6 +123,13 @@ class CassalogImpl implements Cassalog {
 
       } else if (i < changeLog.size) {
         validateChange(change, changeLog[i])
+        if (changeLog[i].appliedAt == null) {
+          if (change.verifyFunction == null || change.verifyFunction()) {
+            updateAppliedAt(i, changeLog[i].timestamp)
+          } else {
+            applyChangeSet(change, i, true)
+          }
+        }
       } else {
         try {
           applyChangeSet(change, i, true)
@@ -168,7 +177,7 @@ class CassalogImpl implements Cassalog {
 
   def createCqlChangeSet(Closure closure, Binding binding) {
     closure.delegate = new CqlChangeSet()
-    def code = closure.rehydrate(closure.delegate, binding, this)
+    def code = closure
     code.resolveStrategy = Closure.DELEGATE_FIRST
     code()
     return code.delegate
@@ -194,6 +203,7 @@ class CassalogImpl implements Cassalog {
   }
 
   Map createScriptHelperFunctions() {
+    def verificationFunctions = new VerificationFunctions(session: session)
     return [
         keyspaceExists: { return keyspaceExists(it) },
         isSchemaVersioned: { return isSchemaVersioned(it) },
@@ -219,7 +229,13 @@ class CassalogImpl implements Cassalog {
           }
           resultSet.all().each { types << it.getString(0) }
           return types
-        }
+        },
+        tableExists: verificationFunctions.&tableExists,
+        tableDoesNotExist: verificationFunctions.&tableDoesNotExist,
+        columnExists: verificationFunctions.&columnExists,
+        columnDoesNotExist: verificationFunctions.&columnDoesNotExist,
+        typeExists: verificationFunctions.&typeExists,
+        typeDoesNotExist: verificationFunctions.&typeDoesNotExist
     ]
   }
 
@@ -246,10 +262,13 @@ class CassalogImpl implements Cassalog {
       return
     }
     insertSchemaChange = session.prepare("""
-      INSERT INTO ${keyspace}.$CHANGELOG_TABLE (bucket, revision, version, applied_at, hash, author, description, tags)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO ${keyspace}.$CHANGELOG_TABLE (bucket, revision, version, hash, author, description, tags)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       """
     )
+
+    updateAppliedAt = session.prepare(
+        "UPDATE ${keyspace}.$CHANGELOG_TABLE SET applied_at = ? WHERE bucket = ? AND revision = ?")
   }
 
   def createChangeLogTableIfNecessary() {
@@ -298,11 +317,28 @@ CREATE TABLE ${keyspace}.$CHANGELOG_TABLE(
 ${changeSet.cql.join('\n')}
 --"""
     )
+    if (updateChangeLog) {
+      insertChangeSet(changeSet, index)
+    }
     changeSet.cql.each { executeCQL(it) }
     if (updateChangeLog) {
-      executeCQL(insertSchemaChange.bind((int) (index / bucketSize), index, changeSet.version, new Date(),
-          changeSet.hash, changeSet.author, changeSet.description, changeSet.tags))
+      updateAppliedAt(index)
     }
+  }
+
+  def insertChangeSet(ChangeSet changeSet, int index) {
+    int bucket = index / bucketSize
+    executeCQL(insertSchemaChange.bind(bucket, index, changeSet.version, changeSet.hash, changeSet.author,
+        changeSet.description, changeSet.tags))
+  }
+
+  def updateAppliedAt(int index) {
+    updateAppliedAt(index, new Date())
+  }
+
+  def updateAppliedAt(int index, Date timestamp) {
+    int bucket = index / bucketSize
+    executeCQL(updateAppliedAt.bind(timestamp, bucket, index))
   }
 
   def toHex(ByteBuffer buffer) {

--- a/src/main/groovy/org/cassalog/core/CassalogImpl.groovy
+++ b/src/main/groovy/org/cassalog/core/CassalogImpl.groovy
@@ -124,7 +124,7 @@ class CassalogImpl implements Cassalog {
       } else if (i < changeLog.size) {
         validateChange(change, changeLog[i])
         if (changeLog[i].appliedAt == null) {
-          if (change.verifyFunction == null || change.verifyFunction()) {
+          if (change.verifyFunction != null && change.verifyFunction()) {
             updateAppliedAt(i, changeLog[i].timestamp)
           } else {
             applyChangeSet(change, i, true)

--- a/src/main/groovy/org/cassalog/core/ChangeSet.groovy
+++ b/src/main/groovy/org/cassalog/core/ChangeSet.groovy
@@ -66,11 +66,18 @@ class ChangeSet {
   String description
 
   /**
+   * This is Cassandra's internal timestamp of when the row was written.
+   */
+  Date timestamp
+
+  /**
    * By default a change set is applied only if it has not already been executed and more precisely not recorded in the
    * change log table. There are times when we want to execute a change set even if it has already been applied. A good
    * example of this would be for the USE <keyspace> statement.
    */
   boolean alwaysRun
+
+  Closure verifyFunction
 
   ByteBuffer getHash() {
     if (hash == null) {
@@ -107,6 +114,10 @@ class ChangeSet {
     if (version == null) {
       throw new ChangeSetValidationException('The version property must be set')
     }
+  }
+
+  void verify(Closure verifyFunction) {
+    this.verifyFunction = verifyFunction
   }
 
 }

--- a/src/main/groovy/org/cassalog/core/VerificationFunctions.groovy
+++ b/src/main/groovy/org/cassalog/core/VerificationFunctions.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cassalog.core
+
+import com.datastax.driver.core.Session
+
+/**
+ * @author jsanda
+ */
+class VerificationFunctions {
+
+  Session session
+
+  def getKeyspaceMetaData(String keyspace) {
+    return session.cluster.metadata.keyspaces.find { it.name == keyspace }
+  }
+
+  boolean tableExists(String keyspace, String table) {
+    return getKeyspaceMetaData(keyspace)?.tables?.find { it.name == table } != null
+  }
+
+  boolean tableDoesNotExist(String keyspace, String table) {
+    return !tableExists(keyspace, table)
+  }
+
+  boolean columnExists(String keyspace, String table, String column) {
+    def tableMetaData = getKeyspaceMetaData(keyspace)?.tables?.find { it.name == table }
+    return tableMetaData?.columns?.find { it.name == column } != null
+  }
+
+  boolean columnDoesNotExist(String keyspace, String table, String column) {
+    return !columnExists(keyspace, table, column)
+  }
+
+  boolean typeExists(String keyspace, String type) {
+    def typesMetaData = getKeyspaceMetaData(keyspace)?.userTypes
+    return typesMetaData?.find { it.name.name() == type } != null
+  }
+
+  boolean typeDoesNotExist(String keyspace, String type) {
+    return !typeExists(keyspace, type)
+  }
+
+}

--- a/src/test/groovy/org/cassalog/core/CassalogBaseTest.groovy
+++ b/src/test/groovy/org/cassalog/core/CassalogBaseTest.groovy
@@ -17,6 +17,7 @@
 package org.cassalog.core
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.PreparedStatement
+import com.datastax.driver.core.QueryOptions
 import com.datastax.driver.core.Row
 import com.datastax.driver.core.Session
 import org.testng.annotations.BeforeSuite
@@ -33,9 +34,14 @@ class CassalogBaseTest {
 
   static Cluster cluster
 
+  static VerificationFunctions verificationFunctions
+
   @BeforeSuite
   static void initTest() {
-    cluster = new Cluster.Builder().addContactPoint('127.0.0.1').build()
+    cluster = new Cluster.Builder()
+        .addContactPoint('127.0.0.1')
+        .withQueryOptions(new QueryOptions(refreshSchemaIntervalMillis: 0))
+        .build()
     session = cluster.connect()
 //    findTableName = session.prepare(
 //        "SELECT columnfamily_name FROM system.schema_columnfamilies " +
@@ -45,6 +51,7 @@ class CassalogBaseTest {
         "SELECT table_name FROM system_schema.tables " +
         "WHERE keyspace_name = ? AND table_name = ?"
     )
+    verificationFunctions = new VerificationFunctions(session: session)
   }
 
   static void resetSchema(String keyspace) {

--- a/src/test/groovy/org/cassalog/core/CassalogTest.groovy
+++ b/src/test/groovy/org/cassalog/core/CassalogTest.groovy
@@ -193,7 +193,7 @@ class CassalogTest extends CassalogBaseTest {
 
     assertTableExists(keyspace, 'test3')
 
-    // Now let's rerun the schema change script to make sure it is a no-op. Doing this will verify that we are searching
+    // Now let's rerun the schema change script to make sure it is a no-op. Doing this will verifyFunction that we are searching
     // across buckets for changes that have already been applied.
     cassalog.execute(script2, [keyspace: keyspace])
   }
@@ -289,4 +289,114 @@ class CassalogTest extends CassalogBaseTest {
     verifyChangeLog(changeLogRows)
   }
 
+
+  @Test
+  void resumeCreateTableWhenChangeWasAlreadyApplied() {
+    String keyspace = 'resume_create_table_applied'
+    resetSchema(keyspace)
+
+    String cql = "CREATE TABLE ${keyspace}.test1 (x int, y text, PRIMARY KEY (x))"
+
+    def script = getClass().getResource('/resume_updates/create_tables.groovy').toURI()
+
+    def cassalog = new CassalogImpl(keyspace: keyspace, session: session)
+    cassalog.createChangeLogTableIfNecessary()
+    cassalog.initPreparedStatements()
+
+    def changeSet = new CqlChangeSet(cql: [cql], version: '1.0')
+    cassalog.insertChangeSet(changeSet, 0)
+
+    cassalog.execute(script, [keyspace: keyspace])
+
+    assertTableExists(keyspace, 'test1')
+    assertTableExists(keyspace, 'test2')
+  }
+
+  @Test
+  void resumeCreateTableWhenChangeHasNotBeenApplied() {
+    String keyspace = 'resume_create_table_not_applied'
+    resetSchema(keyspace)
+
+    String cql = "CREATE TABLE ${keyspace}.test1 (x int, y text, PRIMARY KEY (x))"
+
+    def script = getClass().getResource('/resume_updates/create_tables.groovy').toURI()
+
+    def cassalog = new CassalogImpl(keyspace: keyspace, session: session)
+    cassalog.createChangeLogTableIfNecessary()
+    cassalog.initPreparedStatements()
+
+    def changeSet = new CqlChangeSet(cql: [cql], version: '1.0')
+    cassalog.insertChangeSet(changeSet, 0)
+
+    cassalog.execute(script, [keyspace: keyspace])
+
+    assertTableExists(keyspace, 'test1')
+    assertTableExists(keyspace, 'test2')
+  }
+
+  @Test
+  void resumeAddColumnWhenChangeWasAlreadyApplied() {
+    String keyspace = 'resume_add_column_applied'
+    resetSchema(keyspace)
+
+    session.execute("CREATE TABLE ${keyspace}.test (x int, y text, PRIMARY KEY (x))")
+
+    def script = getClass().getResource('/resume_updates/columns.groovy').toURI()
+
+    def cassalog = new CassalogImpl(keyspace: keyspace, session: session)
+    cassalog.createChangeLogTableIfNecessary()
+    cassalog.initPreparedStatements()
+
+    def addColumn = new CqlChangeSet(cql: ["ALTER TABLE ${keyspace}.test ADD z text"], version: '1.0')
+
+    cassalog.insertChangeSet(addColumn, 0)
+
+    cassalog.execute(script, [keyspace: keyspace])
+
+    // No assertions necessary, just want to make sure cassalog runs without error
+  }
+
+  @Test
+  void resumeAddColumnWhenChangeHasNotBeenApplied() {
+    String keyspace = 'resume_add_column_not_applied'
+    resetSchema(keyspace)
+
+    session.execute("CREATE TABLE ${keyspace}.test (x int, y text, PRIMARY KEY (x))")
+
+    def script = getClass().getResource('/resume_updates/columns.groovy').toURI()
+
+    def cassalog = new CassalogImpl(keyspace: keyspace, session: session)
+    cassalog.createChangeLogTableIfNecessary()
+    cassalog.initPreparedStatements()
+
+    def addColumn = new CqlChangeSet(cql: ["ALTER TABLE ${keyspace}.test ADD z text"], version: '1.0')
+
+    cassalog.insertChangeSet(addColumn, 0)
+    cassalog.execute(script, [keyspace: keyspace])
+
+    assertTrue(verificationFunctions.columnExists(keyspace, 'test', 'z'))
+  }
+
+  @Test
+  void resumeDropColumnWhenChangeHasBeenApplied() {
+    String keyspace = 'resume_drop_column_applied'
+    resetSchema(keyspace)
+
+    session.execute("CREATE TABLE ${keyspace}.test (x int, y text, PRIMARY KEY (x))")
+
+    def script = getClass().getResource('/resume_updates/columns.groovy').toURI()
+
+    def cassalog = new CassalogImpl(keyspace: keyspace, session: session)
+    cassalog.createChangeLogTableIfNecessary()
+    cassalog.initPreparedStatements()
+
+    def addColumn = new CqlChangeSet(cql: ["ALTER TABLE ${keyspace}.test ADD z text"], version: '1.0')
+    def dropColumn = new CqlChangeSet(cql: ["ALTER TABLE ${keyspace}.test DROP y"], version: '2.0')
+
+    cassalog.applyChangeSet(addColumn, 0, true)
+    cassalog.insertChangeSet(dropColumn, 1)
+    cassalog.execute(script, [keyspace: keyspace])
+
+    assertTrue(verificationFunctions.columnDoesNotExist(keyspace, 'test', 'y'))
+  }
 }

--- a/src/test/resources/resume_updates/columns.groovy
+++ b/src/test/resources/resume_updates/columns.groovy
@@ -1,0 +1,11 @@
+schemaChange {
+  version '1.0'
+  cql "ALTER TABLE ${keyspace}.test ADD z text"
+  verify { columnExists(keyspace, "test", "z") }
+}
+
+schemaChange {
+  version '2.0'
+  cql "ALTER TABLE ${keyspace}.test DROP y"
+  verify { columnDoesNotExist(keyspace, "test", "z") }
+}

--- a/src/test/resources/resume_updates/create_tables.groovy
+++ b/src/test/resources/resume_updates/create_tables.groovy
@@ -1,0 +1,16 @@
+schemaChange {
+  version '1.0'
+  cql "CREATE TABLE ${keyspace}.test1 (x int, y text, PRIMARY KEY (x))"
+  verify { tableExists(keyspace, "test1") }
+}
+
+schemaChange {
+  version '2.0'
+  cql """
+CREATE TABLE ${keyspace}.test2 (
+      x int,
+      y text,
+      PRIMARY KEY (x)
+    )
+"""
+}

--- a/src/test/resources/resume_updates/insert.groovy
+++ b/src/test/resources/resume_updates/insert.groovy
@@ -1,0 +1,10 @@
+schemaChange {
+  version '1.0'
+  cql "CREATE TABLE ${keyspace}.test (x int PRIMARY KEY, y int)"
+  verify { tableExists(keyspace, "test") }
+}
+
+schemaChange {
+  version '2.0'
+  cql "INSERT INTO ${keyspace}.test (x, y) VALUES (1, 2)"
+}


### PR DESCRIPTION
There are several changes to make sure we are in a consistent state.

Previously the schema change would be applied and then the changelog table would get updated. With this commit, we now first update the changelog table, but the applied_at column is not updated. We then apply the schema change(s). Then we set the applied_at column.

There is also a new changeset function in the cassalog scripts. It is named verify and it accepts a closure that should return a boolean. The purpose of this function is to verify whether or not a schema change has been applied.

Here is an example:

```
    schemaChange {
      author 'jsanda'
      version '1.0'
      cql "CREATE TABLE test (x int PRIMARY KEY, y int)"
      verify { tableExists(keyspacec, 'test') }
    }
```

When Cassalog encounters this schema change, it goes through the steps described above. If the schema change is already in the changelog table, and the applied_at column is null, then the verify function is called if it is defined. If the function returns true, Cassalog interprets this to mean that
the schema change has already been applied and the applied_at column is set. If the verify function returns false, the schema change is applied and then the applied_at column is set.
